### PR TITLE
remove api layer remap

### DIFF
--- a/remap.config
+++ b/remap.config
@@ -193,7 +193,7 @@
 map http://www.twreporter.org/__HC__ http://127.0.0.1:8083/synthetic.txt
 map http://www.twreporter.org/0/ http://0media.tw/p/
 map http://www.twreporter.org/i/ https://twreporter.github.io/infographics/
-map http://www.twreporter.org/api/ http://api.twreporter.org/
+# map http://www.twreporter.org/api/ http://api.twreporter.org/
 map http://www.twreporter.org/reader_api/ https://twreporter.atavist.com/reader_api/
 map http://www.twreporter.org/data/ https://twreporter.atavist.com/data/
 map http://www.twreporter.org/static/ https://twreporter.atavist.com/static/


### PR DESCRIPTION
reference: https://github.com/twreporter/twreporter-react/pull/160

We have API layer on top of our FE server,
so we don't need to have this remap rule.

@hcchien  
