### PR TITLE
Force content into cache.

### DIFF
--- a/records.config
+++ b/records.config
@@ -252,7 +252,7 @@ CONFIG proxy.config.http.cache.when_to_add_no_cache_to_msie_requests INT -1
    #   0 - No required headers to make document cachable
    #   1 - "Last-Modified:", "Expires:", or "Cache-Control: max-age" required
    #   2 - explicit lifetime required, "Expires:" or "Cache-Control: max-age"
-CONFIG proxy.config.http.cache.required_headers INT 2
+CONFIG proxy.config.http.cache.required_headers INT 0
 CONFIG proxy.config.http.cache.max_stale_age INT 604800
 CONFIG proxy.config.http.cache.range.lookup INT 1
 CONFIG proxy.config.http.cache.range.write INT 0


### PR DESCRIPTION
@garfieldduck @hcchien 

Right now, our content from real-v2 is not cacheable because we don't add cache header in the response header.

Here is the way to cache those content without cache header.
